### PR TITLE
style: set max line length in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+max_line_length = 80
 
 [*.{js,json,yml}]
 charset = utf-8


### PR DESCRIPTION
Setting `max_line_length` in `.editorconfig` makes both Prettier and visual guides in the IDE use the same value.

Even though EditorConfig [documentation](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length) says `max_line_length` "forces hard line wrapping after the amount of characters specified", this is actually not a hard limit when used together with Prettier: https://prettier.io/docs/en/options#print-width