### PR TITLE
build(deps): move vitest-mock-extended from core to project root

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "prettier": "3.2.5",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.6.0",
-    "vitest": "^1.5.0"
+    "vitest": "^1.5.0",
+    "vitest-mock-extended": "^2.0.0"
   },
   "resolutions": {
     "@vitejs/plugin-react": ">=4.2.1",

--- a/packages/aoboshi-core/package.json
+++ b/packages/aoboshi-core/package.json
@@ -12,8 +12,5 @@
   },
   "dependencies": {
     "@js-temporal/polyfill": "^0.4.4"
-  },
-  "devDependencies": {
-    "vitest-mock-extended": "^2.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5608,7 +5608,6 @@ __metadata:
   resolution: "@vvornanen/aoboshi-core@workspace:packages/aoboshi-core"
   dependencies:
     "@js-temporal/polyfill": "npm:^0.4.4"
-    vitest-mock-extended: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5647,6 +5646,7 @@ __metadata:
     typescript: "npm:^5.4.5"
     typescript-eslint: "npm:^7.6.0"
     vitest: "npm:^1.5.0"
+    vitest-mock-extended: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Test dependencies should be in the project root since that's where vitest runs.