### PR TITLE
build(app): change electron main process and preload to use es modules

### DIFF
--- a/packages/aoboshi-app/package.json
+++ b/packages/aoboshi-app/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "main": ".vite/build/main.js",
+  "type": "module",
   "scripts": {
     "rebuild:sqlite": "electron-rebuild -f -w better-sqlite3",
     "make": "yarn rebuild:sqlite && electron-forge make",

--- a/packages/aoboshi-app/src/main/MainApplicationContext.ts
+++ b/packages/aoboshi-app/src/main/MainApplicationContext.ts
@@ -64,7 +64,7 @@ export const getMainApplicationContext = (): MainApplicationContext => {
       logLevel: getEnvironmentVariable("LOGLEVEL", "info"),
       resourcesPath:
         process.env.NODE_ENV === "development"
-          ? path.join(__dirname, "../../src/resources")
+          ? path.join(import.meta.dirname, "../../src/resources")
           : process.resourcesPath,
     };
 

--- a/packages/aoboshi-app/src/main/MainWindow.ts
+++ b/packages/aoboshi-app/src/main/MainWindow.ts
@@ -19,7 +19,7 @@ export class MainWindow {
       titleBarStyle: "hiddenInset",
       trafficLightPosition: { x: 20, y: 18 },
       webPreferences: {
-        preload: path.join(__dirname, "preload.js"),
+        preload: path.join(import.meta.dirname, "preload.mjs"),
       },
     });
 
@@ -49,7 +49,10 @@ export class MainWindow {
       await this.window.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);
     } else {
       await this.window.loadFile(
-        path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`),
+        path.join(
+          import.meta.dirname,
+          `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`,
+        ),
       );
     }
   }

--- a/packages/aoboshi-app/src/main/Scheduler.ts
+++ b/packages/aoboshi-app/src/main/Scheduler.ts
@@ -23,7 +23,7 @@ export class Scheduler implements OnAfterInit {
 
   constructor(context: MainApplicationContext) {
     this.bree = new Bree({
-      root: path.join(__dirname, "jobs"),
+      root: path.join(import.meta.dirname, "jobs"),
       worker: {
         // Pass application properties to worker threads
         env: propertiesAsEnv(context.properties),

--- a/packages/aoboshi-app/src/main/migration/MigrationService.ts
+++ b/packages/aoboshi-app/src/main/migration/MigrationService.ts
@@ -40,7 +40,7 @@ const getContentHash = (path: string): string => {
 };
 
 const getMigrationFiles = (): MigrationFile[] => {
-  const migrationsDir = join(__dirname, "migrations");
+  const migrationsDir = join(import.meta.dirname, "migrations");
 
   return fs
     .readdirSync(migrationsDir)

--- a/packages/aoboshi-app/vite.main.config.ts
+++ b/packages/aoboshi-app/vite.main.config.ts
@@ -30,7 +30,7 @@ export default defineConfig((env) => {
       lib: {
         entry: forgeConfigSelf.entry,
         fileName: () => "[name].js",
-        formats: ["cjs"],
+        formats: ["es"],
       },
       rollupOptions: {
         external: [...external, "better-sqlite3"],

--- a/packages/aoboshi-app/vite.preload.config.ts
+++ b/packages/aoboshi-app/vite.preload.config.ts
@@ -14,11 +14,10 @@ export default defineConfig((env) => {
         // Preload scripts may contain Web assets, so use the `build.rollupOptions.input` instead `build.lib.entry`.
         input: forgeConfigSelf.entry,
         output: {
-          format: "cjs",
           // It should not be split chunks.
           inlineDynamicImports: true,
-          entryFileNames: "[name].js",
-          chunkFileNames: "[name].js",
+          entryFileNames: "[name].mjs",
+          chunkFileNames: "[name].mjs",
           assetFileNames: "[name].[ext]",
         },
       },


### PR DESCRIPTION
`aoboshi-app` was the only package still using CommonJS because Electron did not support ES Modules when this project was created. Support for ESM was added in electron v28. Setting type `module` in `package.json` makes all packages consistent and helps migrating to ESM-only Storybook v10.

See: https://www.electronjs.org/docs/latest/tutorial/esm